### PR TITLE
fix: remove trailing whitespace

### DIFF
--- a/chapter1/PEP_right_or_wrong.md
+++ b/chapter1/PEP_right_or_wrong.md
@@ -9,67 +9,67 @@ Which of the below alignments are correct?
 
 - [ ] b
 
-        abs_area = (area_A + area_B 
+        abs_area = (area_A + area_B
             + area_C + area_D)
 
 - [ ] c
 
-        result = my_function(area_A, area_B, 
+        result = my_function(area_A, area_B,
             area_C, area_D)
 
 - [ ] d
 
-        result = my_function(area_A, area_B, 
+        result = my_function(area_A, area_B,
                              area_C, area_D)
 
 - [ ] e
 
         result = my_function(
-            area_A, area_B, 
+            area_A, area_B,
             area_C, area_D
             )
 
 # 2. Naming conventions
 
-Which of the below naming conventions are correct?  
+Which of the below naming conventions are correct?
 
-Classes:  
-- [ ] a `class my-first-analysis:` 
-- [ ] b `class my_first_analysis:` 
-- [ ] c `class Myfirstanalysis:` 
-- [ ] d `class MyFirstAnalysis:`   
+Classes:
+- [ ] a `class my-first-analysis:`
+- [ ] b `class my_first_analysis:`
+- [ ] c `class Myfirstanalysis:`
+- [ ] d `class MyFirstAnalysis:`
 
-Functions:  
-- [ ] a `def calc_area(x):` 
-- [ ] b `def calc-area(x):` 
-- [ ] c `def calcarea(x):` 
-- [ ] d `def Calc_area(x):`   
+Functions:
+- [ ] a `def calc_area(x):`
+- [ ] b `def calc-area(x):`
+- [ ] c `def calcarea(x):`
+- [ ] d `def Calc_area(x):`
 
-Variables:  
+Variables:
 - [ ] a `O = abs(x)`
 - [ ] b `I = abs(x)`
 - [ ] c `l = abs(x)`
-- [ ] d `abs_x = abs(x)`  
+- [ ] d `abs_x = abs(x)`
 
-Constants:  
+Constants:
 - [ ] a `THRESHOLD = 0.1`
 - [ ] b `threshold = 0.1`
 - [ ] c `Threshold = 0.1`
-- [ ] d `T = 0.1`  
+- [ ] d `T = 0.1`
 
-Other:  
+Other:
 - [ ] a `list = my_areas`
 - [ ] b `list_ = my_areas`
 - [ ] c `__list__ = my_areas`
-- [ ] d `_list = my_areas`  
+- [ ] d `_list = my_areas`
 
-Modules:  
+Modules:
 - [ ] a `Numerical.py`
 - [ ] b `numerical.py`
 - [ ] c `numerical_analysis.py`
 - [ ] d `numerical-analysis.py`
 
-Packages:  
+Packages:
 - [ ] a `MyCoolPackage`
 - [ ] b `my-cool-package`
 - [ ] c `my_cool_package`


### PR DESCRIPTION
Removing trailing whitespace, which is a common on-save configuration, is also
detected as a difference by the CI.
